### PR TITLE
Fix: Translation Typos

### DIFF
--- a/resource/localization/en-pt/npc_spawn_platforms.properties
+++ b/resource/localization/en-pt/npc_spawn_platforms.properties
@@ -9,7 +9,7 @@ tool.npc_spawnplatform.npc=Non-Pirate-Character
 tool.npc_spawnplatform.all_npcs=All Foes
 tool.npc_spawnplatform.weapon=Armarment
 tool.npc_spawnplatform.skill=Shootin' Prowess
-tool.npc_spawnplatform.skill.help=Where 0 be a landlubber and 4 be captain kidd himself
+tool.npc_spawnplatform.skill.help=Where 0 be a landlubber and 4 be Captain Kidd himself
 
 tool.npc_spawnplatform.panel_spawning=Spawnin' Rates
 tool.npc_spawnplatform.delay=Spawnin' Delay
@@ -41,7 +41,7 @@ tool.npc_spawnplatform.squads.help2=BEWARE: If ye navies grow bigger than 16 cre
 tool.npc_spawnplatform.customsquads=Use a Navy
 tool.npc_spawnplatform.squadoverride=Navy Country
 tool.npc_spawnplatform.oldspawning=Ye Olden Spawnin' Routine
-tool.npc_spawnplatform.oldspawning.help=If ye prefer the old ways, thsi be f' ye
+tool.npc_spawnplatform.oldspawning.help=If ye prefer the old ways, this be f' ye
 tool.npc_spawnplatform.killvalue=Treasure
 tool.npc_spawnplatform.killvalue.help=Get ye some treasure for yer battle\u000ASet to -1 if fighting be its own reward
 

--- a/resource/localization/en/npc_spawn_platforms.properties
+++ b/resource/localization/en/npc_spawn_platforms.properties
@@ -34,7 +34,7 @@ tool.npc_spawnplatform.spawnheight=Spawn Height
 tool.npc_spawnplatform.spawnradius=Spawn Distance
 
 tool.npc_spawnplatform.panel_other=Other
-tool.npc_spawnplatform.healthmul=Health mUltiplier
+tool.npc_spawnplatform.healthmul=Health multiplier
 tool.npc_spawnplatform.frozen=Spawn Frozen
 tool.npc_spawnplatform.squads.help1=NPCs use squads for improved tactics. By default there is 1 squad per platform, but you can use a shared squad to join two platforms together.
 tool.npc_spawnplatform.squads.help2=WARNING: A squad can have a maximum of 16 NPCs in it and won't behave properly if you try to add more.
@@ -76,4 +76,4 @@ utilities.spawnplatform.dangerzone=Danger Zone
 utilities.spawnplatform.sanity=Valid NPC Check
 utilities.spawnplatform.sanity.help=Only spawn NPCs on the NPC list. If you disable this option, players can spawn any entity they want and potentially crash the server (or worse!)
 utilities.spawnplatform.rehydrate=Missing NPCs on Dupe Fix
-utilities.spawnplatform.rehydrate.help=If you duplicate a platform but not it's NPCs, it will re-spawn all NPCs the old platform had.\u000AThis is important for saves and persistance (which use the duplicator under the hood) but may be suprising with the duplicator tool.\u000AIf you do not use persistance and want freshly duplicated platforms to have no NPCs, untick this.
+utilities.spawnplatform.rehydrate.help=If you duplicate a platform but not it's NPCs, it will re-spawn all NPCs the old platform had.\u000AThis is important for saves and persistence (which use the duplicator under the hood) but may be suprising with the duplicator tool.\u000AIf you do not use persistence and want freshly duplicated platforms to have no NPCs, untick this.


### PR DESCRIPTION
Fixing a few minor typos in the translation files found while generating the German translations.